### PR TITLE
Add support for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "php": "^7.1",
         "astrotomic/laravel-translatable": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/contracts": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/routing": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/translation": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*"
+        "illuminate/contracts": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/routing": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/translation": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.0.*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
# Description

This PR add support for Laravel 6.0 released on Septembre 6th, 2019.