### PR TITLE
feat: add support php 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.4, 8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4, 8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "8.5.*",
         "astrotomic/laravel-translatable": "^11.0|^12.0",
         "illuminate/contracts": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "8.5.*",
+        "php": "^8.2",
         "astrotomic/laravel-translatable": "^11.0|^12.0",
         "illuminate/contracts": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0",


### PR DESCRIPTION
This pull request updates the PHP version requirements for the project to ensure compatibility with the latest PHP release. The main changes are focused on restricting the supported PHP versions in both the Composer configuration and the test workflow.

**Dependency and CI configuration updates:**

* Updated the `composer.json` file to require PHP version `8.5.*` exclusively, dropping support for earlier PHP versions.
* Modified the GitHub Actions test workflow (`.github/workflows/tests.yml`) to run tests only on PHP versions 8.4 and 8.5, removing 8.2 and 8.3 from the matrix.

Ref: #57416