### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*,12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -33,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -24,17 +24,17 @@
     ],
     "require": {
         "php": "^8.2",
-        "astrotomic/laravel-translatable": "^11.0|^12.0",
-        "illuminate/contracts": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0",
-        "illuminate/routing": "^11.0|^12.0",
-        "illuminate/translation": "^11.0|^12.0"
+        "astrotomic/laravel-translatable": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/routing": "^11.0|^12.0|^13.0",
+        "illuminate/translation": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.2",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "suggest": {


### PR DESCRIPTION
Ref #58942

This pull request updates the package to support Laravel 13 and PHPUnit 12, expanding compatibility and updating the CI workflow to test against these new versions. The changes ensure that the package can be used with the latest Laravel and PHPUnit releases and that the test matrix accurately reflects the supported combinations.

**Dependency and compatibility updates:**

* Added support for Laravel 13 and updated the `composer.json` to allow `astrotomic/laravel-translatable`, `illuminate/*`, and `orchestra/testbench` dependencies at version 13, as well as `phpunit/phpunit` at version 12.

**Continuous Integration (CI) improvements:**

* Expanded the GitHub Actions test matrix in `.github/workflows/tests.yml` to include Laravel 13 and PHPUnit 12, ensuring that tests run against all supported combinations.
* Updated the dependency installation step in the workflow to explicitly require the correct version of `phpunit/phpunit` based on the matrix, improving test reliability.
* Adjusted the test matrix to exclude unsupported combinations of Laravel and PHPUnit or PHP versions, preventing unnecessary or failing test runs.
* Enhanced the workflow job naming to include the PHPUnit version, making it easier to identify which combination is being tested.